### PR TITLE
Guard uses of double with macros and pragmas.

### DIFF
--- a/include/pencil_opencl.h
+++ b/include/pencil_opencl.h
@@ -28,11 +28,15 @@
 #define PENCIL_OPENCL_H
 
 float sinf(float x) { return sin(x); }
-double sind(double x) { return sin(x); }
 float cosf(float x) { return cos(x); }
+float mixf(float x, float y, float a) { return mix(x, y, a); }
+
+#ifdef cl_khr_fp64
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+double sind(double x) { return sin(x); }
 double cosd(double x) { return cos(x); }
-
-float mixf(float x, float y, float a) { return mix(x,y,a); }
-double mixd(double x, double y, double a) { return mix(x,y,a); }
-
+double mixd(double x, double y, double a) { return mix(x, y, a); }
+#pragma OPENCL EXTENSION cl_khr_fp64 : disable
 #endif
+
+#endif /* ifndef PENCIL_OPENCL_H */


### PR DESCRIPTION
According to the OpenCL specification, the OpenCL compiler has a full right to complain when it sees a use of the `double` data type without a corresponding use of `#pragma OPENCL EXTENSION cl_khr_fp64 : enable`. To ensure this `#pragma` can be used without errors, it needs to be guarded with a check that the `cl_khr_fp64` macro is defined (which happens iff the implementation supports the `cl_khr_fp64` extension).
